### PR TITLE
Fix: Applet resizing issues

### DIFF
--- a/sdk/src/core/context.ts
+++ b/sdk/src/core/context.ts
@@ -47,7 +47,6 @@ export class AppletContext extends EventTarget {
       window.addEventListener('DOMContentLoaded', this.initialize.bind(this));
     }
 
-    this.createResizeObserver();
     this.attachListeners();
   }
 
@@ -78,6 +77,8 @@ export class AppletContext extends EventTarget {
     const readyEvent = new AppletReadyEvent();
     this.dispatchEvent(readyEvent);
     if (typeof this.onready === 'function') this.onready(readyEvent);
+
+    this.createResizeObserver();
   }
 
   createResizeObserver() {

--- a/sdk/src/core/shared.ts
+++ b/sdk/src/core/shared.ts
@@ -112,6 +112,7 @@ export class AppletMessageRelay {
     const listener = async (messageEvent: MessageEvent<AppletMessage>) => {
       if (messageEvent.source === window.self) return;
       if (messageEvent.data.type !== messageType) return;
+      if (messageEvent.source !== this.target) return;
 
       const message = new AppletMessage(
         messageEvent.data.type,


### PR DESCRIPTION
## Description

Two bugs we're solving here:

1. Applets sometimes do not resize when first loaded
2. Applets resize to whatever the latest applet size is defined as

For the first, we're moving the resizeObserver setup code to the end of the initialize function. This ensures the resize events are sent _after_ the load and ready events, and appropriate listeners will have been set up to respond to it.

For the second, we're adding an early return to the `on message` listener, to discriminate against iframe messages that have a different source than our own.