### PR TITLE
feat(inspector): Update schema and params for valid json

### DIFF
--- a/inspector/web/components/app-sidebar.css
+++ b/inspector/web/components/app-sidebar.css
@@ -25,6 +25,7 @@ app-sidebar fieldset {
   border: none;
   padding: 0;
   margin: 0;
+  min-width: 0;
 }
 
 app-sidebar .status-message {
@@ -53,6 +54,7 @@ app-sidebar select {
   font-size: 12px;
   border-radius: 4px;
   border: 1px solid var(--color-border);
+  overflow: auto;
 }
 
 app-sidebar textarea {

--- a/inspector/web/components/app-sidebar.css
+++ b/inspector/web/components/app-sidebar.css
@@ -75,3 +75,10 @@ app-sidebar input[type='submit'] {
 app-sidebar input[type='submit']:hover {
   background: var(--color-border);
 }
+
+app-sidebar .error-message {
+  padding: 4px;
+  border-radius: 3px;
+  color: #f44336;
+  border: solid 1px #f44336;
+}

--- a/inspector/web/components/app-sidebar.ts
+++ b/inspector/web/components/app-sidebar.ts
@@ -14,6 +14,9 @@ export class AppSidebar extends LitElement {
   @property({ attribute: false })
   actions: AppletAction[] = [];
 
+  @property({ type: String })
+  schemaError: string = '';
+
   connectedCallback() {
     store.subscribe((data: StorageData) => {
       if (!data.applet) return;
@@ -25,6 +28,35 @@ export class AppSidebar extends LitElement {
   handleSelect(e: InputEvent) {
     const select = e.target as HTMLSelectElement;
     this.selected = select.selectedIndex;
+  }
+
+  handleSchemaChange(e: InputEvent) {
+    const textarea = e.target as HTMLTextAreaElement;
+
+    const trimmed = textarea.value.trim();
+
+    if (!trimmed) {
+      this.schemaError = '';
+      textarea.setCustomValidity('');
+      return;
+    }
+    try {
+      const parsed = JSON.parse(trimmed);
+      const formatted = JSON.stringify(parsed, null, 2);
+
+      textarea.value = formatted;
+      this.schemaError = '';
+      textarea.setCustomValidity('');
+    } catch (err) {
+      this.schemaError = err.message;
+      textarea.setCustomValidity('Invalid JSON');
+    }
+  }
+
+  handleSchemaFocus(e: InputEvent) {
+    const textarea = e.target as HTMLTextAreaElement;
+
+    textarea.setCustomValidity('');
   }
 
   handleSubmit(e: SubmitEvent) {
@@ -61,7 +93,17 @@ export class AppSidebar extends LitElement {
         </fieldset>
         <fieldset>
           <label>Params</label>
-          <textarea rows=${6} name="params">{}</textarea>
+          <textarea
+            rows=${6}
+            name="params"
+            @focus=${this.handleSchemaFocus}
+            @change=${this.handleSchemaChange.bind(this)}
+          >
+{}</textarea
+          >
+          ${this.schemaError
+            ? html`<div class="error-message">${this.schemaError}</div>`
+            : ''}
         </fieldset>
         <fieldset>
           <input type="submit" value="Dispatch action" />


### PR DESCRIPTION
## Description

* Fix a bug where the user could not see long descriptions as the `pre` tag could not overflow
* Update the params `textarea`, to validate and format json

## Screenshot

![inspector-json-validation](https://github.com/user-attachments/assets/782e3a5f-e34f-4d42-943a-c326e9120784)
