### PR TITLE
fix(inspector): allow vertical overflow in applet

### DIFF
--- a/inspector/web/components/app-root.css
+++ b/inspector/web/components/app-root.css
@@ -1,6 +1,6 @@
 app-root {
   width: 100%;
-  height: 100%;
+  height: 100dvh;
   display: flex;
   flex-direction: column;
 }
@@ -8,5 +8,5 @@ app-root {
 app-root main {
   flex-grow: 1;
   display: flex;
-  height: 100%;
+  overflow: hidden;
 }

--- a/inspector/web/components/app-sidebar.css
+++ b/inspector/web/components/app-sidebar.css
@@ -2,13 +2,11 @@ app-sidebar {
   width: 400px;
   border-right: 1px solid var(--color-border);
   padding: 13px;
-  height: 100%;
   flex-shrink: 0;
 }
 
 app-sidebar form {
   width: 100%;
-  height: 100%;
   display: flex;
   gap: 15px;
   flex-direction: column;

--- a/inspector/web/components/app-viewer.css
+++ b/inspector/web/components/app-viewer.css
@@ -22,6 +22,7 @@ app-viewer .container {
 
 applet-frame {
   flex-grow: 1;
+  overflow: scroll;
 }
 
 app-viewer .data-view {


### PR DESCRIPTION
## What Happens

When the applet grows vertically beyond a certain size, the inspector extends beyond the viewport, the applet content gets cropped, and the bottom bar ("View as") disappears.

## What Is Expected

 - The inspector must be contained within the viewport.
 - The applet view must be scrollable when its content overflows.
 - The "View as" bar must always be displayed.

## Screenshots

### Before
![Screenshot From 2025-02-04 13-11-42](https://github.com/user-attachments/assets/eac01833-909a-4ba1-a556-f81995b8513f)
The inspector extends beyond the viewport (see the scrollbar), and the bottom part of the applet viewer (+ "View as" bar) is cut off.

### After
![Screenshot From 2025-02-04 13-18-40](https://github.com/user-attachments/assets/c9f465f6-7141-4390-a1c2-ff6262d8089e)
The inspector is fully contained within the page, and the applet view is scrollable.
