### PR TITLE
fix(inspector): Remove height and allow container to overflow.

### DIFF
--- a/inspector/web/components/app-root.css
+++ b/inspector/web/components/app-root.css
@@ -8,7 +8,7 @@ app-root {
 app-root main {
   flex-grow: 1;
   display: flex;
-  height: 100%;
+  overflow: auto;
 }
 
 app-root .column {

--- a/inspector/web/components/app-viewer.css
+++ b/inspector/web/components/app-viewer.css
@@ -3,6 +3,7 @@ app-viewer {
   background: #f4f4f4;
   padding: 16px;
   display: flex;
+  overflow: auto;
 }
 
 app-viewer .hidden {
@@ -17,7 +18,6 @@ app-viewer .container {
   flex-grow: 1;
   border: 1px solid var(--color-border);
   border-radius: 6px;
-  overflow: hidden;
 }
 
 applet-frame {
@@ -30,6 +30,7 @@ app-viewer .data-view {
   padding: 8px;
   margin: 0;
   white-space: pre-wrap;
+  overflow: auto;
 }
 
 app-viewer .applet-footer {


### PR DESCRIPTION
We want the main container to grow to fill the rest of the screen, not 100% height, as we also have the header taking up space.

We also want to enable overflow on app-viewer and the data view, this way we keep our "footers" in place but allow the inner windows to scroll.

![data-view-overflow](https://github.com/user-attachments/assets/4eb07f54-7f15-4560-845e-c6cc6674a006)
