### PR TITLE
404 error on docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > An open spec & SDK for creating web apps that agents can use.
 
-🌐 [Docs](https://unternet.co/docs) | 👾 [Community Discord](https://discord.gg/VsMuEKmqvt) | 💌 [Mailing List](https://buttondown.com/unternet)
+🌐 [Docs](https://unternet.co/docs/) | 👾 [Community Discord](https://discord.gg/VsMuEKmqvt) | 💌 [Mailing List](https://buttondown.com/unternet)
 
 [![Mozilla builders logo](docs/assets/builders.png)](https://builders.mozilla.org/)
 


### PR DESCRIPTION
`/docs` returns a 404, `/docs/` does not.