### PR TITLE
fix(schema): check if params has any keys

### DIFF
--- a/inspector/web/lib/model.ts
+++ b/inspector/web/lib/model.ts
@@ -34,7 +34,7 @@ function getResponseSchema(applet: Applet) {
               required: ['id'],
             };
 
-            if (action.parameters) {
+            if (action.parameters && Object.keys(action.parameters).length > 0) {
               schema.properties.arguments = action.parameters;
 
               // Set some variables that OpenAI requires if they're not present


### PR DESCRIPTION
In cases where the params was an empty object, this was erroring out 
@rupertsworld is fixing this on the applet side so it comes back as undefined but probably worth to keep this check here regardless