### PR TITLE
add history context chat

### DIFF
--- a/inspector/web/components/app-history.css
+++ b/inspector/web/components/app-history.css
@@ -1,0 +1,52 @@
+app-history {
+  flex: 1;
+  border-left: 1px solid var(--color-border);
+  padding: 13px;
+  height: 100%;
+  flex-shrink: 0;
+}
+
+app-history .history {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+app-history .bubble-container {
+  display: flex;
+}
+
+/* Align assistant bubbles to the left */
+app-history .assistant-bubble-container {
+  justify-content: flex-start;
+}
+
+/* Align user bubbles to the right */
+app-history .user-bubble-container {
+  justify-content: flex-end;
+}
+
+app-history .bubble {
+  display: inline-block;
+  border-radius: 16px;
+  padding: 8px 12px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  background-color: #f1f8e9;
+  max-width: 80%;
+  text-align: left;
+  min-width: 50%;
+}
+
+/* User bubbles get a different background color */
+app-history .user {
+  background-color: #e0f7fa;
+}
+
+app-history strong {
+  display: block;
+  margin-bottom: 4px;
+}
+
+app-history span {
+  white-space: pre-line;
+}

--- a/inspector/web/components/app-history.ts
+++ b/inspector/web/components/app-history.ts
@@ -1,0 +1,94 @@
+import { LitElement, html } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import './app-history.css';
+import { historyContext, Interaction } from '../lib/history-context';
+
+@customElement('app-history')
+export class AppHistory extends LitElement {
+  createRenderRoot() {
+    return this;
+  }
+
+  @state()
+  interactions: Interaction[] = [];
+
+  private unsubscribe?: () => void;
+
+  connectedCallback() {
+    super.connectedCallback();
+    // Subscribe to updates in the history context.
+    this.unsubscribe = historyContext.subscribe((interactions) => {
+      // Create a new array reference to trigger reactivity.
+      this.interactions = [...interactions];
+    });
+  }
+
+  disconnectedCallback() {
+    this.unsubscribe && this.unsubscribe();
+    super.disconnectedCallback();
+  }
+
+  render() {
+    // Helper function to dynamically render all properties of the output,
+    // excluding the "type" property.
+    const renderOutputProperties = (output: any): string => {
+      return Object.entries(output)
+        .filter(([key]) => key !== 'type')
+        .map(([key, value]) => `${key}: ${value}`)
+        .join(', ');
+    };
+
+    return html`
+      <div class="history">
+        ${this.interactions.map((interaction) => {
+          // Render input bubble (always user)
+          const inputBubble = html`
+            <div class="bubble-container user-bubble-container">
+              <div class="bubble user">
+                <strong>You:</strong>
+                <span>${interaction.input.text}</span>
+              </div>
+            </div>
+          `;
+
+          let outputBubble = html``;
+          if (interaction.outputs && interaction.outputs.length > 0) {
+            const output = interaction.outputs[0];
+            let containerClass = '';
+            let label = '';
+            let outputContent = '';
+
+            if (interaction.input.type === 'command') {
+              // For "command", the output is from the assistant.
+              containerClass = 'assistant-bubble-container';
+              label = 'Assistant:';
+              outputContent = `ACTION: ${
+                interaction.id
+              },\n${renderOutputProperties(output)}`;
+            } else if (interaction.input.type === 'action') {
+              // For "action", the output is from the user (omit the ID).
+              containerClass = 'user-bubble-container';
+              label = 'You:';
+              outputContent = renderOutputProperties(output);
+            }
+
+            outputBubble = html`
+              <div class="bubble-container ${containerClass}">
+                <div
+                  class="bubble ${interaction.input.type === 'command'
+                    ? 'assistant'
+                    : 'user'}"
+                >
+                  <strong>${label}</strong>
+                  <span>${outputContent}</span>
+                </div>
+              </div>
+            `;
+          }
+
+          return html`${inputBubble}${outputBubble}`;
+        })}
+      </div>
+    `;
+  }
+}

--- a/inspector/web/components/app-root.ts
+++ b/inspector/web/components/app-root.ts
@@ -5,6 +5,7 @@ import './app-header';
 import './app-viewer';
 import './app-sidebar';
 import './app-prompt';
+import './app-history';
 import './settings-dialog';
 
 @customElement('app-root')
@@ -22,6 +23,7 @@ export class UrlInput extends LitElement {
           <app-viewer></app-viewer>
           <app-prompt></app-prompt>
         </div>
+        <app-history></app-history>
       </main>
       <settings-dialog></settings-dialog>
     `;

--- a/inspector/web/components/app-sidebar.css
+++ b/inspector/web/components/app-sidebar.css
@@ -1,5 +1,5 @@
 app-sidebar {
-  width: 400px;
+  flex: 1;
   border-right: 1px solid var(--color-border);
   padding: 13px;
   height: 100%;

--- a/inspector/web/components/app-sidebar.ts
+++ b/inspector/web/components/app-sidebar.ts
@@ -3,6 +3,7 @@ import { customElement, property } from 'lit/decorators.js';
 import './app-sidebar.css';
 import { StorageData, store } from '../lib/store';
 import { AppletActionDescriptor } from '@web-applets/sdk';
+import { historyContext, Interaction } from '../lib/history-context';
 
 @customElement('app-sidebar')
 export class AppSidebar extends LitElement {
@@ -66,6 +67,15 @@ export class AppSidebar extends LitElement {
     const formData = new FormData(form);
     const actionId = formData.get('action-id') as string;
     const params = formData.get('params') as string;
+
+    // Add the user's action to the context.
+    historyContext.addInteraction({
+      id: actionId,
+      input: { type: 'action', text: actionId },
+      outputs: [{ type: actionId, ...JSON.parse(params) }],
+      timestamp: Date.now(),
+    });
+
     window.applet.sendAction(actionId, JSON.parse(params));
   }
 

--- a/inspector/web/lib/history-context.ts
+++ b/inspector/web/lib/history-context.ts
@@ -1,0 +1,92 @@
+// Extended the input type to allow actions from the user
+export interface CommandInput {
+  type: 'command' | 'action';
+  text: string;
+}
+
+export type InteractionInput = CommandInput;
+
+export interface DataOutput {
+  type: 'data';
+  resourceUrl: string;
+  content: object;
+}
+
+export interface TextOutput {
+  type: 'text';
+  content: string;
+}
+
+export interface WebOutput {
+  type: 'web';
+  processId: number;
+}
+
+export interface AppletOutput {
+  type: string;
+  arguments: object;
+}
+
+export type InteractionOutput =
+  | TextOutput
+  | DataOutput
+  | WebOutput
+  | AppletOutput;
+
+// The Interaction type now contains an input (from the user), outputs (from the model),
+// and a timestamp for when the interaction occurred.
+export interface Interaction {
+  id?: string | number;
+  input: InteractionInput;
+  outputs: InteractionOutput[];
+  timestamp: number;
+}
+
+type Subscriber = (interactions: Interaction[]) => void;
+
+class HistoryContext {
+  private interactions: Interaction[] = [];
+  private subscribers = new Set<Subscriber>();
+
+  // Add an interaction and notify subscribers
+  addInteraction(interaction: Interaction): void {
+    this.interactions.push(interaction);
+    this.notify();
+  }
+
+  // Return all interactions as a new array (to maintain immutability)
+  getAllInteractions(): Interaction[] {
+    return [...this.interactions];
+  }
+
+  // Return the last `limit` interactions for context
+  getRecentInteractions(limit: number = 10): Interaction[] {
+    return this.interactions.slice(-limit);
+  }
+
+  // Clear the history and notify subscribers
+  clearHistory(): void {
+    this.interactions = [];
+    this.notify();
+  }
+
+  // Subscribe to changes in the history.
+  // Returns an unsubscribe function.
+  subscribe(callback: Subscriber): () => void {
+    this.subscribers.add(callback);
+    // Immediately call the callback with a copy of the current interactions.
+    callback([...this.interactions]);
+    return () => {
+      this.subscribers.delete(callback);
+    };
+  }
+
+  // Notify all subscribers with a new array reference so that lit detects changes.
+  private notify(): void {
+    for (const cb of this.subscribers) {
+      cb([...this.interactions]);
+    }
+  }
+}
+
+export const historyContext = new HistoryContext();

--- a/inspector/web/lib/model.ts
+++ b/inspector/web/lib/model.ts
@@ -2,6 +2,7 @@ import { createOpenAI } from '@ai-sdk/openai';
 import { store } from './store';
 import { generateObject, jsonSchema } from 'ai';
 import { Applet } from '@web-applets/sdk';
+import type { Interaction } from './history-context';
 
 function getSystemPrompt(applet: Applet) {
   const prompt = `\
@@ -64,7 +65,16 @@ function getResponseSchema(applet: Applet) {
   );
 }
 
-async function getModelResponse(prompt: string, applet: Applet) {
+async function getModelResponse(
+  prompt: string,
+  history: Interaction[],
+  applet: Applet
+) {
+  const contextText = history.map((interaction) =>
+    JSON.stringify(interaction.id)
+  );
+  const fullPrompt = contextText ? `${contextText}\n${prompt}` : prompt;
+
   /**
    * @TODO
    *
@@ -84,7 +94,7 @@ async function getModelResponse(prompt: string, applet: Applet) {
 
   const { object } = await generateObject({
     model,
-    prompt: prompt,
+    prompt: fullPrompt,
     system: systemPrompt,
     schema: responseSchema,
   });

--- a/inspector/web/tsconfig.json
+++ b/inspector/web/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "lib": ["ES2020", "DOM"],
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true
+    "emitDecoratorMetadata": true,
+    "downlevelIteration": true
   }
 }


### PR DESCRIPTION
Adds a history context and displays the chat to the user.

Uses a very similar model and types to the Operator system. There will be some work required to get the context sent through to the model to be properly factored in. This main PR is for the UI and alignment of user and assistant models including when the user manually triggers an action.

<img width="1512" alt="Screenshot 2025-03-04 at 8 02 53 PM" src="https://github.com/user-attachments/assets/7efe632f-2c01-4710-9141-38bde45f2e7e" />
