### PR TITLE
fix: Missing type parameter in register return type

### DIFF
--- a/sdk/src/applets/applet-factory.ts
+++ b/sdk/src/applets/applet-factory.ts
@@ -23,7 +23,7 @@ export class AppletFactory {
     });
   }
 
-  register<DataType = any>(manifest?: Object): AppletScope {
+  register<DataType = any>(manifest?: Object): AppletScope<DataType> {
     return new AppletScope<DataType>(manifest);
   }
 }


### PR DESCRIPTION
Fixes the following issue:
<img width="409" alt="Screenshot 2025-03-07 at 22 12 44" src="https://github.com/user-attachments/assets/d0f233b4-70af-4a29-9972-f841c6c774bb" />
