### PR TITLE
Fix foreground color for text area input

### DIFF
--- a/inspector/web/global.css
+++ b/inspector/web/global.css
@@ -91,6 +91,7 @@ body {
 }
 
 input,
+textarea,
 button {
   color: inherit;
   background-color: inherit;


### PR DESCRIPTION
Updates the foreground color on the parameters input:

##Before:
<img width="345" alt="Screenshot 2025-03-10 at 3 59 56 PM" src="https://github.com/user-attachments/assets/a6e93759-9e72-4e15-a583-6a73d001e46d" />


##After:
<img width="340" alt="Screenshot 2025-03-10 at 3 59 41 PM" src="https://github.com/user-attachments/assets/b115e23c-6e6d-478b-8d45-9317d13dcae1" />
