### PR TITLE
Add rollup optional dependency

### DIFF
--- a/inspector/package.json
+++ b/inspector/package.json
@@ -33,7 +33,9 @@
     "@types/express": "^5.0.0",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^22.7.5",
-    "typescript": "^5.6.2",
-    "rollup": "^4.34.9"
+    "typescript": "^5.6.2"
+  },
+  "optionalDependencies": {
+    "@rollup/rollup-linux-x64-gnu": "4.9.5"
   }
 }


### PR DESCRIPTION
Fixes cloud build error for Vite in the inspector.