### PR TITLE
Fix bug with manifest & minification

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.4",
+  "version": "0.2.5",
   "workspaces": [
     "sdk",
     "inspector",

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -12,8 +12,7 @@ Web Applets is a [Mozilla Builders](https://builders.mozilla.org/) project.
 
 **Web Applets is an open specification for building software that both humans and AI can understand and use together.** Instead of forcing AI to operate traditional point-and-click apps built for humans, Web Applets creates a new kind of web software designed for human-AI collaboration. You can read more about it on our website.
 
-- [Motivation](https://unternet.co/docs/web-applets/introduction)
-- [Getting started with building an applet](https://unternet.co/docs/web-applets/creating-an-applet)
+Read [the docs](https://unternet.co/docs/web-applets/introduction)!
 
 ![Demo of a web applets chatbot](.assets/applets-chat-demo.gif)
 

--- a/sdk/scripts/build.js
+++ b/sdk/scripts/build.js
@@ -5,7 +5,6 @@ esbuild
   .build({
     entryPoints: {
       'web-applets.min': './src/polyfill.js',
-      'elements/applet-frame': './src/elements/applet-frame.ts',
     },
     bundle: true,
     minify: true,

--- a/sdk/src/applets/applet-scope.ts
+++ b/sdk/src/applets/applet-scope.ts
@@ -159,19 +159,18 @@ export class AppletScope<DataType = any> extends EventTarget {
       return;
     }
 
-    // TODO: Add timeout
     try {
       const manifestRequest = await fetch(manifestLinkElem.href);
       const manifest = (await manifestRequest.json()) as AppletManifest;
       for (const key in manifest.actions) {
         const action = manifest.actions[key];
-        if (action.params_schema && !isEmpty(this.#actions.params_schema)) {
+        if (action.params_schema && isEmpty(action.params_schema)) {
           action.params_schema = undefined;
         }
       }
       return manifest;
     } catch (e) {
-      return;
+      console.warn('Failed to fetch manifest', e.message);
     }
   }
 

--- a/sdk/src/elements/applet-frame.ts
+++ b/sdk/src/elements/applet-frame.ts
@@ -112,4 +112,6 @@ export class AppletFrameElement extends HTMLElement {
   }
 }
 
+export const test = 'test';
+
 customElements.define('applet-frame', AppletFrameElement);


### PR DESCRIPTION
Incorrect conditions on the code that checks the manifest.

Also fixed an issue where the `applet-frame.js` file was being minified, preventing the rest of the sdk from importing it.