### PR TITLE
Fixes #138

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "web-applets",
-  "version": "0.2.1",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.2.1",
+      "version": "0.2.5",
       "workspaces": [
         "sdk",
         "inspector",

--- a/sdk/src/applets/applet-factory.ts
+++ b/sdk/src/applets/applet-factory.ts
@@ -4,7 +4,7 @@ import { Applet } from './applet.js';
 import { AppletScope } from './applet-scope.js';
 
 export class AppletFactory {
-  async connect<DataType = any>(window: Window): Promise<Applet> {
+  async connect<DataType = any>(window: Window): Promise<Applet<DataType>> {
     return new Promise((resolve, reject) => {
       const applet = new Applet<DataType>(window);
       const timeout = setTimeout(() => {
@@ -23,7 +23,7 @@ export class AppletFactory {
     });
   }
 
-  register<DataType = any>(manifest?: Object): AppletScope {
+  register<DataType = any>(manifest?: Object): AppletScope<DataType> {
     return new AppletScope<DataType>(manifest);
   }
 }

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -2,11 +2,11 @@
 import { AppletFactory } from './applets/applet-factory.js';
 export const applets = new AppletFactory();
 
-// Applet & AppletScope (as types, not intantiable classes)
+// Applet & AppletScope (as types, not instantiable classes)
 import { Applet as AppletClass } from './applets/applet.js';
 import { AppletScope as AppletScopeClass } from './applets/applet-scope.js';
-export type Applet = InstanceType<typeof AppletClass>;
-export type AppletScope = InstanceType<typeof AppletScopeClass>;
+export type Applet<DataType = any> = AppletClass<DataType>;
+export type AppletScope<DataType = any> = AppletScopeClass<DataType>;
 
 // AppletFrame
 import './elements/applet-frame.js';


### PR DESCRIPTION
Small PR to fix #138

Preserves the original intent to not export instantiable classes.
Also adds missing type parameters in the return value of the `AppletFactory` methods.